### PR TITLE
fix file path bug

### DIFF
--- a/src/main/java/priv/zxw/ratel/landlords/client/javafx/listener/ClientListenerUtils.java
+++ b/src/main/java/priv/zxw/ratel/landlords/client/javafx/listener/ClientListenerUtils.java
@@ -109,7 +109,7 @@ public class ClientListenerUtils {
         List<Class<?>> classList = new ArrayList<>(classFiles.length);
         for (File classFile : classFiles) {
             String absolutePath = classFile.getAbsolutePath();
-            String classFullName = absolutePath.substring(classpath.length() - 1, absolutePath.lastIndexOf("."))
+            String classFullName = absolutePath.substring(classpath.length(), absolutePath.lastIndexOf("."))
                     .replace(File.separator, ".");
 
             try {


### PR DESCRIPTION
String classFullName = absolutePath.substring(classpath.length()-1, absolutePath.lastIndexOf("."))
                    .replace(File.separator, ".");
when subString  == /priv/zxw/ratel/landlords/client/javafx/listener
replace is .priv.zxw.ratel.landlords.client.javafx.listener
the head dot is redundant
the result is wrong